### PR TITLE
Use webui.send_raw() instead of webui.run() for log in backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed a bug where the task status was incorrectly displayed as interrupted when restarting a failed task.
+- The task status was incorrectly displayed as interrupted when restarting a failed task.
+- Quote in log message lead to decoding error. #27
 
 ## 0.3.0 - 2024-1-22
 

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,9 +1,15 @@
 #pragma once
 
+#include "nlohmann/json.hpp"
 #include "webui.hpp"
 
 #include <format>
 #include <string_view>
+
+namespace ytweb
+{
+
+using Json = nlohmann::json;
 
 class Logger
 {
@@ -42,7 +48,13 @@ class Logger
     template <typename... Args>
     void log(std::string_view level, std::format_string<Args...> format, Args&&... args)
     {
-        auto message = std::format(format, std::forward<Args>(args)...);
-        window_->run(std::format(R"js(logMessage("{}", "{}"))js", level, message));
+        Json json;
+        json.emplace("level", level);
+        json.emplace("message", std::format(format, std::forward<Args>(args)...));
+
+        std::string raw = json.dump();
+        window_->send_raw("logMessage", raw.data(), raw.size());
     }
 };
+
+} // namespace ytweb

--- a/web/src/environment/global.d.ts
+++ b/web/src/environment/global.d.ts
@@ -1,6 +1,6 @@
 declare global {
     interface Window {
-        logMessage: (level: string, message: string) => void;
+        logMessage: (rawData: Uint8Array) => void;
         showDownloadProgress: (rawData: Uint8Array) => void;
         showDownloadInfo: (rawData: Uint8Array) => void;
         showPreviewInfo: (rawData: Uint8Array) => void;

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -27,9 +27,17 @@ function showDownloadProgress(rawData: Uint8Array) {
     tasks.setProgress(id, progress);
 }
 
-window.logMessage = (level: string, message: string) => {
+window.logMessage = (rawData: Uint8Array) => {
+    const str = new TextDecoder().decode(rawData);
+
+    const { level, message } = JSON.parse(str);
+    if (level === undefined || message === undefined || typeof level !== 'string' || typeof message !== 'string') {
+        log.error(`Invalid log message: ${str}`);
+        return;
+    }
+
     if (!logLevels.includes(level as LogLevel)) {
-        console.error(`Invalid log level: ${level}. The message will not be logged.`);
+        log.error(`Invalid log level: ${level}.`);
         return;
     }
 


### PR DESCRIPTION
Fix #27 