### PR TITLE
Feature/cmdline web path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased - 2025-2-6
+## Unreleased - 2025-2-7
 
 ### Added
 
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enabled automatic line wrapping for long log entries.
 - Used [SysCmdLine](https://github.com/SineStriker/syscmdline) to parse cmdline arguments.
 - Enabled specifying runtime environment by cmdline argument "--runtime". Useful aliases "--browser" and "--webview" are provided.
+- Enabled specifying web file path by cmdline argument "--server-path".
 
 ### Changed
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More detailed log messages when users perform actions.
   - Handled exceptions and logged error messages when the frontend sends an invalid request.
   - Added a warning when sending an interrupt request to a non-running task.
+- Macro "YT_DLP_WEB_PATH" is removed, replaced by a soft link created on building.
 
 ### Fixed
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -17,8 +17,6 @@ namespace ytweb
 
 namespace fs = std::filesystem;
 
-static fs::path const INDEX_PATH = YT_DLP_WEB_PATH;
-
 using Json = nlohmann::json;
 
 using TaskId = TaskManager::TaskId;
@@ -124,20 +122,29 @@ void App::handle_interrupt(webui::window::event* event)
 
 void App::init()
 {
-    // Check if the index.html file exists.
-    if (!fs::exists(INDEX_PATH) || !fs::is_directory(INDEX_PATH))
-    {
-        throw std::runtime_error("Path not exist: " + INDEX_PATH.string());
-    }
-    if (!fs::exists(INDEX_PATH / "index.html") || !fs::is_regular_file(INDEX_PATH / "index.html"))
-    {
-        throw std::runtime_error("index.html not exist in: " + INDEX_PATH.string());
-    }
-
-    window_.set_root_folder(INDEX_PATH.string());
-
     window_.bind("handleRequest", [](webui::window::event* event) { App::instance().handle_request(event); });
     window_.bind("handleInterrupt", [](webui::window::event* event) { App::instance().handle_interrupt(event); });
+}
+
+void App::set_server_dir(std::filesystem::path const& server_dir)
+{
+    if (!fs::exists(server_dir))
+    {
+        throw ytweb::PathError("Path not exist: {}", server_dir.string());
+    }
+
+    if (!fs::is_directory(server_dir))
+    {
+        throw ytweb::PathError("Path is not a directory: {}", server_dir.string());
+    }
+
+    auto index = server_dir / "index.html";
+    if (!fs::exists(index) || !fs::is_regular_file(index))
+    {
+        throw ytweb::PathError("index.html not found in the server directory: {}", server_dir.string());
+    }
+
+    window_.set_root_folder(server_dir.string());
 }
 
 void App::run()

--- a/src/app.h
+++ b/src/app.h
@@ -5,6 +5,8 @@
 #include "task_manager.h"
 #include "webui.hpp"
 
+#include <filesystem>
+
 namespace ytweb
 {
 
@@ -24,6 +26,8 @@ class App
     {
         runtime_ = runtime;
     }
+
+    void set_server_dir(std::filesystem::path const& server_dir);
 
   private:
     App() = default;

--- a/src/exception.h
+++ b/src/exception.h
@@ -18,4 +18,15 @@ class ParseError : public std::runtime_error
     }
 };
 
+class PathError : public std::runtime_error
+{
+  public:
+    using std::runtime_error::runtime_error;
+    template <typename... Args>
+    explicit PathError(std::format_string<Args...> format, Args&&... args)
+        : std::runtime_error(std::format(format, std::forward<Args>(args)...))
+    {
+    }
+};
+
 } // namespace ytweb

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,30 +1,35 @@
 #include "app.h"
+#include "exception.h"
 #include "runtime.h"
 #include "syscmdline/parser.h"
 #include "syscmdline/system.h"
+
+#include <iostream>
 
 namespace SCL = SysCmdLine;
 
 int main()
 {
-    auto runtime_option = SCL::Option({"--runtime", "-r"}, "Set the runtime to use.");
+    SCL::Option runtime_option({"--runtime", "-r"}, "Set the runtime to use.");
     runtime_option.setRequired(false);
-    runtime_option.addArgument(SCL::Argument("runtime").expect({
-        "no",
-        "browser",
-        "chrome",
-        "firefox",
-        "edge",
-        "safari",
-        "chromium",
-        "opera",
-        "brave",
-        "vivaldi",
-        "epic",
-        "yandex",
-        "chromium",
-        "webview",
-    }));
+    runtime_option.addArgument(SCL::Argument("runtime")
+                                   .expect({
+                                       "no",
+                                       "browser",
+                                       "chrome",
+                                       "firefox",
+                                       "edge",
+                                       "safari",
+                                       "chromium",
+                                       "opera",
+                                       "brave",
+                                       "vivaldi",
+                                       "epic",
+                                       "yandex",
+                                       "chromium",
+                                       "webview",
+                                   })
+                                   .default_value("webview"));
 
     SCL::Option browser_option({"--browser", "-b"}, "Show in browser. Alias for '--runtime browser'.");
     browser_option.setRequired(false);
@@ -32,12 +37,19 @@ int main()
     SCL::Option webview_option({"--webview", "-w"}, "Show in webview. Alias for '--runtime webview'. (Default)");
     webview_option.setRequired(false);
 
+    SCL::Option server_dir_option(
+        {"--server-dir", "-s"}, "Set the path to the web server files.\n"
+                                "Default is the 'server' directory in the same directory as the executable."
+    );
+    server_dir_option.setRequired(false);
+    server_dir_option.addArgument(SCL::Argument("path").default_value("server"));
+
     SCL::Command root_command("yt-dlp-web");
     root_command.addHelpOption();
     root_command.addOptions({runtime_option, browser_option, webview_option});
+    root_command.addOptions({server_dir_option});
     root_command.setHandler([&](SCL::ParseResult const& result) {
         auto& app = ytweb::App::instance();
-        app.init();
 
         if (result.isOptionSet(browser_option))
         {
@@ -47,7 +59,7 @@ int main()
         {
             app.set_runtime(ytweb::Runtime::Webview);
         }
-        else if (result.isOptionSet(runtime_option))
+        else
         {
             auto runtime = ytweb::get_runtime(result.valueForOption(runtime_option).toString());
             if (runtime.has_value())
@@ -56,6 +68,18 @@ int main()
             }
         }
 
+        try
+        {
+            auto server_dir = std::filesystem::absolute(result.valueForOption(server_dir_option).toString());
+            app.set_server_dir(server_dir);
+        }
+        catch (ytweb::PathError const& e)
+        {
+            std::cerr << e.what() << "\n";
+            return 1;
+        }
+
+        app.init();
         app.run();
 
         return 0;

--- a/xmake.lua
+++ b/xmake.lua
@@ -15,8 +15,15 @@ add_requires("syscmdline")
 target("main", function()
     set_kind("binary")
     add_files("src/*.cpp")
-    add_defines('YT_DLP_WEB_PATH="$(projectdir)/web/dist"')
     add_packages("webui", "nlohmann_json", "boost", "syscmdline")
+
+    after_build(function(target)
+        if is_mode("debug") then
+            local server_dir = path.join(target:targetdir(), "server")
+            os.tryrm(server_dir)
+            os.ln("$(projectdir)/web/dist", server_dir)
+        end
+    end)
 end)
 
 option("enable_test", function()


### PR DESCRIPTION
#33 

在添加命令行参数以指定 Web 文件路径的同时，移除了老旧的使用宏来管理该路径的方法。作为替代，xmake 在 Debug 模式构建的时候会自动在相同目录下创建一个名为 server 的软链接，指向 Web 文件夹，便于开发。